### PR TITLE
adding features for token refresh

### DIFF
--- a/client/src/api/axios.js
+++ b/client/src/api/axios.js
@@ -6,6 +6,15 @@ const instance = axios.create({
   baseURL: BASE_URL,
 });
 
+function getDeviceId() {
+  let id = localStorage.getItem('deviceId');
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem('deviceId', id);
+  }
+  return id;
+}
+
 // Attach token only to protected endpoints (not /auth/*)
 instance.interceptors.request.use(config => {
   const token = localStorage.getItem('token');
@@ -37,7 +46,10 @@ instance.interceptors.response.use(
         if (!refreshToken) throw new Error('No refresh token available');
 
         // Attempt to refresh access token
-        const refreshResponse = await axios.post('/auth/refresh', { refreshToken });
+        const refreshResponse = await axios.post('/auth/refresh', {
+          refreshToken,
+          deviceId: getDeviceId(),
+        });
 
         const newAccessToken = refreshResponse.data.accessToken;
         localStorage.setItem('token', newAccessToken);

--- a/client/src/components/Protected.js
+++ b/client/src/components/Protected.js
@@ -15,8 +15,22 @@ function Protected() {
       });
   }, []);
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    const refreshToken = localStorage.getItem('refreshToken');
+    const accessToken = localStorage.getItem('token');
+
+    try {
+      await axios.post('/auth/logout', { refreshToken }, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+    } catch (err) {
+      console.warn('Logout request failed or token was already removed');
+    }
+
     localStorage.removeItem('token');
+    localStorage.removeItem('refreshToken');
     navigate('/login');
   };
 

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -2,6 +2,15 @@ import React, { useState } from 'react';
 import axios from '../api/axios';
 import { useNavigate } from 'react-router-dom';
 
+function getDeviceId() {
+  let id = localStorage.getItem('deviceId');
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem('deviceId', id);
+  }
+  return id;
+}
+
 function Login() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -11,7 +20,7 @@ function Login() {
   const handleLogin = async (e) => {
     e.preventDefault();
     try {
-      const res = await axios.post('/auth/login', { username, password });
+      const res = await axios.post('/auth/login', { username, password, deviceId: getDeviceId()});
       localStorage.setItem('token', res.data.accessToken);
       localStorage.setItem('refreshToken', res.data.refreshToken);
       navigate('/protected');

--- a/client/src/pages/ResetPassword.js
+++ b/client/src/pages/ResetPassword.js
@@ -9,12 +9,28 @@ function ResetPassword() {
   const [newPassword, setNewPassword] = useState('');
   const [confirm, setConfirm] = useState('');
   const [message, setMessage] = useState('');
+  const [validToken, setValidToken] = useState(false);
+  const [checked, setChecked] = useState(false);
+
   const navigate = useNavigate();
 
   useEffect(() => {
     if (!token) {
-      setMessage('Invalid or missing reset token.');
+      setMessage('Missing reset token.');
+      setChecked(true);
+      return;
     }
+
+    axios.get('/auth/validate-reset-token', { params: { token } })
+      .then(() => {
+        setValidToken(true);
+      })
+      .catch((err) => {
+        setMessage(err.response?.data || 'Invalid or expired token.');
+      })
+      .finally(() => {
+        setChecked(true);
+      });
   }, [token]);
 
   const handleSubmit = async (e) => {
@@ -35,27 +51,31 @@ function ResetPassword() {
     }
   };
 
+  if (!checked) return <p>Checking token...</p>;
+
   return (
     <div>
       <h2>Reset Password</h2>
-      {message && <p>{message}</p>}
-      <form onSubmit={handleSubmit}>
-        <input
-          type="password"
-          placeholder="New Password"
-          value={newPassword}
-          onChange={(e) => setNewPassword(e.target.value)}
-          required
-        />
-        <input
-          type="password"
-          placeholder="Confirm Password"
-          value={confirm}
-          onChange={(e) => setConfirm(e.target.value)}
-          required
-        />
-        <button type="submit" disabled={!token}>Reset Password</button>
-      </form>
+      {message && <p style={{ color: validToken ? 'green' : 'red' }}>{message}</p>}
+      {validToken && (
+        <form onSubmit={handleSubmit}>
+          <input
+            type="password"
+            placeholder="New Password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            placeholder="Confirm Password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            required
+          />
+          <button type="submit" disabled={!token}>Reset Password</button>
+        </form>
+      )}
     </div>
   );
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       EMAIL_USERNAME: ${EMAIL_USERNAME}
       EMAIL_PASSWORD: ${EMAIL_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
       DB_HOST: db
       DB_PORT: 5432
       DB_NAME: authdb

--- a/src/main/java/webapp_withauth/authapp/jobs/PendingUserCleanupJob.java
+++ b/src/main/java/webapp_withauth/authapp/jobs/PendingUserCleanupJob.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import webapp_withauth.authapp.repository.PasswordResetTokenRepository;
 import webapp_withauth.authapp.repository.PendingUserRepository;
+import webapp_withauth.authapp.repository.RefreshTokenRepository;
 
 import java.time.LocalDateTime;
 
@@ -17,6 +18,7 @@ public class PendingUserCleanupJob {
 
     private final PendingUserRepository pendingUserRepo;
     private final PasswordResetTokenRepository resetTokenRepo;
+    private final RefreshTokenRepository refreshTokenRepo;
 
     // Run every 10 minutes
     @Scheduled(fixedRate = 10 * 60 * 1000)
@@ -35,5 +37,10 @@ public class PendingUserCleanupJob {
     @Scheduled(fixedRate = 5 * 60 * 1000)
     public void cleanExpiredResetTokens() {
         resetTokenRepo.deleteAllByExpiryBefore(LocalDateTime.now());
+    }
+
+    @Scheduled(fixedRate = 5 * 60 * 1000)
+    public void cleanExpiredRefreshTokens() {
+        refreshTokenRepo.deleteAllByExpiryBefore(LocalDateTime.now());
     }
 }

--- a/src/main/java/webapp_withauth/authapp/model/AuthRequest.java
+++ b/src/main/java/webapp_withauth/authapp/model/AuthRequest.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class AuthRequest {
     private String username;
     private String password;
+    private String deviceId;
 }

--- a/src/main/java/webapp_withauth/authapp/model/RefreshRequest.java
+++ b/src/main/java/webapp_withauth/authapp/model/RefreshRequest.java
@@ -5,4 +5,5 @@ import lombok.Data;
 @Data
 public class RefreshRequest {
     private String refreshToken;
+    private String deviceId;
 }

--- a/src/main/java/webapp_withauth/authapp/model/RefreshToken.java
+++ b/src/main/java/webapp_withauth/authapp/model/RefreshToken.java
@@ -1,0 +1,32 @@
+package webapp_withauth.authapp.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    private LocalDateTime expiry;
+
+    private boolean revoked;
+
+    private String ip;
+
+    private String userAgent;
+
+    private String deviceId;
+}

--- a/src/main/java/webapp_withauth/authapp/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/webapp_withauth/authapp/repository/PasswordResetTokenRepository.java
@@ -4,6 +4,7 @@ import webapp_withauth.authapp.model.PasswordResetToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import jakarta.transaction.Transactional;
@@ -19,6 +20,6 @@ public interface PasswordResetTokenRepository extends JpaRepository<PasswordRese
 
     @Modifying
     @Transactional
-    @Query("DELETE FROM PasswordResetToken t WHERE t.email = :email")
-    void deleteAllByExpiryBefore(LocalDateTime time);
+    @Query("DELETE FROM PasswordResetToken t WHERE t.expiry < :now")
+    void deleteAllByExpiryBefore(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/webapp_withauth/authapp/repository/RefreshTokenRepository.java
+++ b/src/main/java/webapp_withauth/authapp/repository/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package webapp_withauth.authapp.repository;
+
+import webapp_withauth.authapp.model.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByToken(String token);
+
+    void deleteAllByUsername(String username);
+
+    void deleteAllByExpiryBefore(LocalDateTime now);
+}

--- a/src/main/java/webapp_withauth/authapp/service/UserService.java
+++ b/src/main/java/webapp_withauth/authapp/service/UserService.java
@@ -20,8 +20,6 @@ public class UserService implements UserDetailsService {
                 .orElseThrow(() -> new UsernameNotFoundException("User not found or not verified"));
 
         System.out.println("🔍 Found user: " + user.getUsername());
-        System.out.println("   Role: " + user.getRole());
-        System.out.println("   Password: " + user.getPassword());
 
         if (user.getRole() == null || user.getRole().isBlank()) {
             throw new IllegalStateException("User role is missing for: " + username);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=authapp

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  application:
+    name: authapp
   mail:
     host: smtp.gmail.com
     port: 587
@@ -22,6 +24,9 @@ spring:
   servlet:
     multipart:
       enabled: true
+
+jwt:
+  secret: ${JWT_SECRET}
 
 logging:
   level:


### PR DESCRIPTION
- Use env vars to store the JWT Secret Management.
- Consider persisting refresh tokens (e.g., in Redis or DB) and implementing rotation + revocation.
- Optionally log IP/device info with refresh tokens and check it during refresh.